### PR TITLE
misc additions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 file(GLOB_RECURSE SOURCES *.c)
 idf_component_register(SRCS ${SOURCES}
                     INCLUDE_DIRS "include" "include/driver"
-                    REQUIRES esp_adc driver)
+                    REQUIRES esp_adc driver fatfs vfs)

--- a/include/board.h
+++ b/include/board.h
@@ -30,6 +30,10 @@ typedef struct td_board_t {
 #define BOARD_SPI_SCK_PIN 40
 #define BOARD_SPI SPI2_HOST
 
+#define BOARD_SDCARD_CS_PIN 39
+
+#define BOARD_RADIO_CS_PIN 9
+
 #define BOARD_I2C_SDA_PIN 18
 #define BOARD_I2C_SCL_PIN 8
 #define BOARD_I2C I2C_NUM_0

--- a/include/sdcard.h
+++ b/include/sdcard.h
@@ -1,0 +1,30 @@
+#ifndef _SDCARD_H_
+#define _SDCARD_H_
+
+#include <string.h>
+#include <sys/unistd.h>
+#include <sys/stat.h>
+#include "esp_vfs_fat.h"
+#include "sdmmc_cmd.h"
+#include "driver/sdmmc_host.h"
+
+#include <dirent.h>
+
+typedef struct td_mountdata_t {
+    const char* mount_point;
+    sdmmc_card_t* card;
+} td_mountdata_t;
+
+
+#define SDCARD_MOUNT_POINT "/sdcard"
+
+bool sdcard_init();
+void* sdcard_mount(const char* mount_point);
+void* sdcard_init_and_mount(const char* mount_point);
+void sdcard_unmount(void* context);
+bool sdcard_is_mounted(void* context);
+
+esp_err_t td_sdcard_init(void *ctx);
+
+
+#endif

--- a/include/speaker.h
+++ b/include/speaker.h
@@ -10,6 +10,7 @@
 #define SAMPLE_RATE 16000
 typedef struct td_speaker_t {
   i2s_chan_handle_t dev;
+  i2s_std_config_t *tx_cfg; // <<<< added this
 } td_speaker_t;
 
 esp_err_t td_speaker_init(void *ctx);

--- a/include/tdeck-lib.h
+++ b/include/tdeck-lib.h
@@ -7,6 +7,7 @@
 #include <keyboard.h>
 #include <trackball.h>
 #include <speaker.h>
+#include <sdcard.h>
 
 esp_err_t td_board_init(td_board_t **Board);
 

--- a/sdcard.c
+++ b/sdcard.c
@@ -1,0 +1,151 @@
+#include <board.h>
+#include <sdcard.h>
+
+#define TAG "tdeck_sdcard"
+
+esp_err_t td_sdcard_init(void *ctx) {
+    return sdcard_init() ? ESP_OK : ESP_ERR_INVALID_ARG;
+}
+
+
+// inspired by https://github.com/ByteWelder/Tactility/tree/main/boards/lilygo_tdeck
+
+/**
+ * Before we can initialize the sdcard's SPI communications, we have to set all
+ * other SPI pins on the board high.
+ * See https://github.com/espressif/esp-idf/issues/1597
+ * See https://github.com/Xinyuan-LilyGO/T-Deck/blob/master/examples/UnitTest/UnitTest.ino
+ * @return success result
+ */
+bool sdcard_init() {
+    ESP_LOGD(TAG, "init");
+
+    gpio_config_t config = {
+        .pin_bit_mask = BIT64(BOARD_SDCARD_CS_PIN) | BIT64(BOARD_RADIO_CS_PIN) | BIT64(BOARD_DISPLAY_CS_PIN),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+
+    if (gpio_config(&config) != ESP_OK) {
+        ESP_LOGE(TAG, "GPIO init failed");
+        return false;
+    }
+
+    if (gpio_set_level(BOARD_SDCARD_CS_PIN, 1) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set board CS pin high");
+        return false;
+    }
+
+    if (gpio_set_level(BOARD_RADIO_CS_PIN, 1) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set radio CS pin high");
+        return false;
+    }
+
+    if (gpio_set_level(BOARD_DISPLAY_CS_PIN, 1) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to set TFT CS pin high");
+        return false;
+    }
+
+    return true;
+}
+
+
+
+
+void* sdcard_mount(const char* mount_point) {
+    ESP_LOGI(TAG, "Mounting %s", mount_point);
+
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+        .format_if_mount_failed = false,
+        .max_files = 4,
+        .allocation_unit_size = 16384,
+        .disk_status_check_enable = false
+    };
+
+    // Init without card detect (CD) and write protect (WD)
+    sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
+    slot_config.gpio_cs = BOARD_SDCARD_CS_PIN;
+    slot_config.host_id = BOARD_SPI;
+
+    sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+    // The following value is from T-Deck repo's UnitTest.ino project:
+    // https://github.com/Xinyuan-LilyGO/T-Deck/blob/master/examples/UnitTest/UnitTest.ino
+    // Observation: Using this automatically sets the bus to 20MHz
+    host.max_freq_khz = 800000U;
+
+    sdmmc_card_t* card;
+    esp_err_t ret = esp_vfs_fat_sdspi_mount(mount_point, &host, &slot_config, &mount_config, &card);
+
+    if (ret != ESP_OK) {
+        if (ret == ESP_FAIL) {
+            ESP_LOGE(TAG, "Mounting failed. Ensure the card is formatted with FAT.");
+        } else {
+            ESP_LOGE(TAG, "Mounting failed (%s)", esp_err_to_name(ret));
+        }
+        return NULL;
+    }
+
+    td_mountdata_t* data = (td_mountdata_t*)malloc(sizeof(td_mountdata_t));
+
+    data->card = card;
+    data->mount_point = mount_point;
+
+    ESP_LOGI(TAG, "Filesystem mounted");
+    // Card has been initialized, print its properties
+    sdmmc_card_print_info(stdout, card);
+
+    // TODO: remove this block
+    {
+        // list the root directory
+        DIR *rootdir = opendir(mount_point);
+        struct dirent * dirent;
+        while((dirent = readdir(rootdir)) != NULL) {
+            ESP_LOGI(TAG, "Found %s, id %d, type %d", dirent->d_name, dirent->d_ino, dirent->d_type);
+        }
+        closedir(rootdir);
+    }
+
+    return data;
+}
+
+void* sdcard_init_and_mount(const char* mount_point) {
+    if (!sdcard_init()) {
+        ESP_LOGE(TAG, "Failed to set SPI CS pins high. This is a pre-requisite for mounting.");
+        return NULL;
+    }
+    td_mountdata_t* data = (td_mountdata_t*)sdcard_mount(mount_point);
+    if (data == NULL) {
+        ESP_LOGE(TAG, "Mount failed for %s", mount_point);
+        return NULL;
+    }
+
+    sdmmc_card_print_info(stdout, data->card);
+
+    return data;
+}
+
+void sdcard_unmount(void* context) {
+    td_mountdata_t* data = (td_mountdata_t*)context;
+    ESP_LOGI(TAG, "Unmounting %s", data->mount_point);
+
+    assert(data != NULL);
+    if (esp_vfs_fat_sdcard_unmount(data->mount_point, data->card) != ESP_OK) {
+        ESP_LOGE(TAG, "Unmount failed for %s", data->mount_point);
+    }
+
+    free(data);
+}
+
+bool sdcard_is_mounted(void* context) {
+    td_mountdata_t* data = (td_mountdata_t*)context;
+    // TODO: use a semaphore lock since SD, Radio and LCD share the same SPI bus
+    //if ( xSemaphoreTake( sd_radio_display_lock, 100 ) ) {
+        bool result = (data != NULL) && (sdmmc_get_status(data->card) == ESP_OK);
+        // xSemaphoreGive( sd_radio_display_lock );
+        return result;
+    //} else {
+    //    return false;
+    //}
+}

--- a/speaker.c
+++ b/speaker.c
@@ -4,31 +4,34 @@
 const static char *TAG = "SPEAKER";
 
 
-
 esp_err_t td_speaker_init(void *ctx) {
   td_board_t *Board = (td_board_t *)ctx;
 
   i2s_chan_config_t tx_chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_0, I2S_ROLE_MASTER);
   ESP_ERROR_CHECK(i2s_new_channel(&tx_chan_cfg, &Board->Speaker.dev, NULL));
 
-  i2s_std_config_t tx_std_cfg = {
-    .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(SAMPLE_RATE),
-      .slot_cfg =  I2S_STD_MSB_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
-      .gpio_cfg =
-          {
-              .mclk = I2S_GPIO_UNUSED,
-
-              .bclk = BOARD_SPEAKER_BCLK_PIN,
-              .ws = BOARD_SPEAKER_WS_PIN,
-              .dout = BOARD_SPEAKER_DIN_PIN,
-              .din = I2S_GPIO_UNUSED,
-              .invert_flags =
-                  {
-                      .mclk_inv = false,
-                      .bclk_inv = false,
-                      .ws_inv = false,
-                  },
-          },
+  // default PCM S16LE 44100
+  static i2s_std_config_t tx_std_cfg = { // << config is static
+    .clk_cfg  = I2S_STD_CLK_DEFAULT_CONFIG(44100),
+    .slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
+    .gpio_cfg =
+      {
+        .mclk = I2S_GPIO_UNUSED,
+        .bclk = BOARD_SPEAKER_BCLK_PIN,
+        .ws =   BOARD_SPEAKER_WS_PIN,
+        .dout = BOARD_SPEAKER_DIN_PIN,
+        .din =  I2S_GPIO_UNUSED,
+        .invert_flags =
+        {
+            .mclk_inv = false,
+            .bclk_inv = false,
+            .ws_inv = false,
+        },
+      },
   };
+
+  Board->Speaker.tx_cfg = &tx_std_cfg; // << stored for later reconfig
+
   return i2s_channel_init_std_mode(Board->Speaker.dev, &tx_std_cfg);
 }
+

--- a/tdeck-lib.c
+++ b/tdeck-lib.c
@@ -48,6 +48,7 @@ esp_err_t td_board_init(td_board_t **Board) {
   ESP_ERROR_CHECK(td_board_i2c_init(*Board));
   ESP_ERROR_CHECK(td_keyboard_init(*Board));
   ESP_ERROR_CHECK(td_speaker_init(*Board));
+  ESP_ERROR_CHECK(td_sdcard_init(*Board));
   gpio_install_isr_service(0);
   ESP_ERROR_CHECK(td_trackball_init(*Board));
 


### PR DESCRIPTION
- init sd at boot. only the pins are prepared, it still needs to be manually mounted:
   `if( sdcard_mount(SDCARD_MOUNT_POINT) == NULL )  ESP_LOGE(TAG, "No SD Card present");`
- make the I2S tx config available as `Speaker.tx_cfg` so it can later be manipilated using  [`i2s_channel_reconfig_std_slot()`](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/i2s.html#_CPPv429i2s_channel_reconfig_std_slot17i2s_chan_handle_tPK21i2s_std_slot_config_t) and [`i2s_channel_reconfig_std_clock()`](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/i2s.html#_CPPv430i2s_channel_reconfig_std_clock17i2s_chan_handle_tPK20i2s_std_clk_config_t)



